### PR TITLE
typo: repeated citation in rendered version

### DIFF
--- a/posts/2025-08-17-baselinenowcast/index.qmd
+++ b/posts/2025-08-17-baselinenowcast/index.qmd
@@ -52,7 +52,7 @@ The `baselinenowcast` package provides modular functions that make implementatio
 
 ## What did we do?
 
-- To address these two gaps, we developed an R package, called baselinenowcast which implements an empirically-driven chain ladder method, based on the approach used by Wolffram et al. @Wolffram2023 as a reference model in the German COVID Nowcast Hub @hospitalization_nowcast_hub_2025 challenge in 2021 and 2022. 
+- To address these two gaps, we developed an R package, called baselinenowcast which implements an empirically-driven chain ladder method, based on the approach used by @Wolffram2023 as a reference model in the German COVID Nowcast Hub @hospitalization_nowcast_hub_2025 challenge in 2021 and 2022. 
 
 - It has a modular function-based interface that enables inspection of the individual components at each step in the nowcasting procedure, which are outlined in the schematic figure.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.
- Bug Fixes
  - None.
- Documentation
  - Standardized citation formatting in the “What did we do?” section of the 2025-08-17 Baselinenowcast post, changing “Wolffram et al. @Wolffram2023” to “@Wolffram2023” for consistency.
  - Minor copy edit only; content, layout, and behavior are unchanged.
- Style
  - Harmonized reference presentation to align with existing citation conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->