### PR TITLE
Update calendar download links

### DIFF
--- a/seminars.qmd
+++ b/seminars.qmd
@@ -20,7 +20,7 @@ A list of scheduled speakers can be found [here](https://docs.google.com/spreads
 
 ## Connect to seminars
 
-You can stay up to date by adding our events to your calendar — via [Google Calendar](https://lshtm.zoom.us/meeting/tZMsc-2urTMqHNJEEwTCYIwmkXgYHHaTg6PD/calendar/google/add?meetingMasterEventId=rd4tOJIGRyuTDseBkNQyVA), [iCal ](https://lshtm.zoom.us/meeting/tZMsc-2urTMqHNJEEwTCYIwmkXgYHHaTg6PD/ics?icsToken=DN7Vq2mM5VOCtHvE3AAALAAAAAIM4GMluI5z0R-ITR-wRtZJGvm8oofc_7JEZsvJOH612ioHdeFN2fV-wSP762v9qioM2mXlxLjWjznRNDAwMDAwMQ&meetingMasterEventId=rd4tOJIGRyuTDseBkNQyVA) or [Outlook calendar ](https://lshtm.zoom.us/meeting/tZMsc-2urTMqHNJEEwTCYIwmkXgYHHaTg6PD/ics?meetingMasterEventId=rd4tOJIGRyuTDseBkNQyVA).
+You can stay up to date by adding our events to your calendar — via [Google Calendar](https://drive.google.com/uc?export=download&id=11lXBWOMwEx5kevSlj1zNMzjsjc7L7XGl), [iCal ](https://drive.google.com/uc?export=download&id=11lXBWOMwEx5kevSlj1zNMzjsjc7L7XGl) or [Outlook calendar ](https://drive.google.com/uc?export=download&id=11lXBWOMwEx5kevSlj1zNMzjsjc7L7XGl).
 
 To join a session directly, just use this Zoom link: [https://lshtm.zoom.us/j/87144638066?pwd=VyjUxZh2tZeeAd68RW5IBQbAZl5gC5.1](https://lshtm.zoom.us/j/87144638066?pwd=VyjUxZh2tZeeAd68RW5IBQbAZl5gC5.1)
 

--- a/seminars/2026-08-05-cathal_mills/index.qmd
+++ b/seminars/2026-08-05-cathal_mills/index.qmd
@@ -14,9 +14,9 @@ Asynchronous discussion will be possible on [our community site](https://communi
 
 ## Connect to seminars
 
-You can sign up for our event calendar here: [Google calendar ](https://lshtm.zoom.us/meeting/tZMsc-2urTMqHNJEEwTCYIwmkXgYHHaTg6PD/calendar/google/add?meetingMasterEventId=rd4tOJIGRyuTDseBkNQyVA)
+You can sign up for our event calendar here: [Google calendar ](https://drive.google.com/uc?export=download&id=11lXBWOMwEx5kevSlj1zNMzjsjc7L7XGl)
 
-Or here for non-Google calendar users: [iCal link ](https://lshtm.zoom.us/meeting/tZMsc-2urTMqHNJEEwTCYIwmkXgYHHaTg6PD/ics?icsToken=DN7Vq2mM5VOCtHvE3AAALAAAAAIM4GMluI5z0R-ITR-wRtZJGvm8oofc_7JEZsvJOH612ioHdeFN2fV-wSP762v9qioM2mXlxLjWjznRNDAwMDAwMQ&meetingMasterEventId=rd4tOJIGRyuTDseBkNQyVA) or [Outlook link ](https://lshtm.zoom.us/meeting/tZMsc-2urTMqHNJEEwTCYIwmkXgYHHaTg6PD/ics?meetingMasterEventId=rd4tOJIGRyuTDseBkNQyVA)
+Or here for non-Google calendar users: [iCal link ](https://drive.google.com/uc?export=download&id=11lXBWOMwEx5kevSlj1zNMzjsjc7L7XGl) or [Outlook link ](https://drive.google.com/uc?export=download&id=11lXBWOMwEx5kevSlj1zNMzjsjc7L7XGl)
 
 Or just join seminars directly here: [https://lshtm.zoom.us/j/87144638066?pwd=VyjUxZh2tZeeAd68RW5IBQbAZl5gC5.1 ](https://lshtm.zoom.us/j/87144638066?pwd=VyjUxZh2tZeeAd68RW5IBQbAZl5gC5.1)
 


### PR DESCRIPTION
Someone found a problem with the calendar download links needing LSHTM SSO if you are external, hopefully this resolves.

<!-- Thanks for opening this pull request! Below we have provided a suggested template for PRs to this repository and a checklist to complete before opening a PR -->
 
## Description

This PR closes #<issue-number>.

[Describe the changes that you made in this pull request.]

## Checklist

- [ ] My PR is based on a package issue and I have explicitly linked it.
- [ ] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [ ] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [ ] I have tested my changes locally.
- [ ] I have added or updated unit tests where necessary.
- [ ] I have updated the documentation if required.
- [ ] My code follows the established coding standards.
- [ ] I have added a news item linked to this PR.
- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated seminar calendar links for Google Calendar, iCal, and Outlook to use the correct shared calendar download location.
  * Applied the corrected links to both the seminar calendar and the August 5, 2026 seminar listing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->